### PR TITLE
Fix workflow file

### DIFF
--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -5,7 +5,7 @@ on:
       - '[0-9]*'
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
       - uses: actions/checkout@v2

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -21,7 +21,7 @@ jobs:
           buildah run ctnr pacman --noconfirm -S git
 
           buildah run ctnr useradd -m dev
-          buildah run ctnr sh -c 'printf "%s\n" "dev ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers.d/dev'
+          buildah run ctnr sh -c 'printf "%s\n" "dev ALL=(ALL:ALL) NOPASSWD: ALL" >>/etc/sudoers.d/dev'
 
           buildah config -u dev ctnr
           buildah run ctnr git clone https://aur.archlinux.org/telegram-desktop-userfonts.git /home/dev/telegram-desktop-userfonts


### PR DESCRIPTION
According to my testing, using ubuntu-20.04 instead of ubuntu-latest (ubuntu-22.04) seems to fix the pacman's errors regarding permissions.

Also, based on my local ArchLinux install, the sudoers file syntax was missing an extra `:ALL`. So I fixed that as well.