### PR TITLE
Run build workflow under GHA container

### DIFF
--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -8,34 +8,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: archlinux/archlinux:base-devel
     steps:
-
-      - name: start build container
-        run: podman run -d --name builder -v ${PWD}:/dest docker.io/library/archlinux:base-devel /sbin/init
 
       - name: prepare build environment
         run: |
-          podman exec builder bash -ec '
           pacman-key --init
           pacman -Sy --noconfirm archlinux-keyring
           pacman -Su --noconfirm
           pacman -S --noconfirm sudo git cmake ninja boost qt6-base
           echo "nobody ALL=(ALL) NOPASSWD: /usr/bin/pacman" | tee -a /etc/sudoers
-          '
 
       - name: build package
         run: |
-          podman exec builder bash -ec '
-          git clone https://aur.archlinux.org/telegram-desktop-userfonts.git /source
-          chown -R nobody /source
-          cd /source
+          git clone https://aur.archlinux.org/telegram-desktop-userfonts.git .
+          chown -R nobody .
           runuser -u nobody -- makepkg --syncdeps --noconfirm --cleanbuild
-          '
 
-      - name: copy built packages
+      - name: list built packages
         run: |
-          podman exec builder bash -ec 'cp -v /source/telegram-desktop-userfonts-*.pkg.* /dest'
-          echo "PKG=$(ls *.pkg.*)" | tee -a $GITHUB_ENV
+          echo "PKG=$(ls telegram-desktop-userfonts-[0-9]*.pkg.*)" | tee -a $GITHUB_ENV
 
       - name: create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -56,6 +56,12 @@ jobs:
         run: |
           echo "PKG=$(ls telegram-desktop-userfonts-[0-9]*.pkg.*)" | tee -a $GITHUB_ENV
 
+      - name: preserve artifcats
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PKG }}
+          path: ${{ env.PKG }}
+
       - name: create release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -16,8 +16,16 @@ jobs:
           pacman-key --init
           pacman -Sy --noconfirm archlinux-keyring
           pacman -Su --noconfirm
-          pacman -S --noconfirm sudo git cmake ninja boost qt6-base
+          pacman -S --noconfirm pacman-contrib sudo docker git cmake extra-cmake-modules ninja meson boost qt6-base
           echo "nobody ALL=(ALL) NOPASSWD: /usr/bin/pacman" | tee -a /etc/sudoers
+
+      - name: clean up some space
+        run: |
+          df -a /
+          paccache -rk0
+          docker image prune --all --force || true
+          rm -rf /__t/*
+          df -a /
 
       - name: build package
         env:

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -32,6 +32,8 @@ jobs:
           AWK_PKGBUILD: |
             # turn off too verbose cmake output
             /DCMAKE_VERBOSE_MAKEFILE/ { next }
+            # turn off exhaustive debuginfo
+            /DCMAKE_BUILD_TYPE/ { print "        -DCMAKE_CXX_FLAGS=-g0 \\" }
             { print }
         run: |
           git clone https://aur.archlinux.org/telegram-desktop-userfonts.git .

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -27,14 +27,30 @@ jobs:
           rm -rf /__t/*
           df -a /
 
+      - name: install sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: build package
         env:
-          SED_PKGBUILD: "/CMAKE_VERBOSE_MAKEFILE/d"
+          AWK_PKGBUILD: |
+            # turn off too verbose cmake output
+            /DCMAKE_VERBOSE_MAKEFILE/ { next }
+            # use sccache in non-unique subdirectory for better hit rate
+            /cmake -B build/ {
+              print "    mv -v tdesktop-*-full tdesktop-full"
+              gsub(/-\$pkgver-/, "-")
+              print
+              print "        -DCMAKE_C_COMPILER_LAUNCHER=sccache \\"
+              print "        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \\"
+              next
+            }
+            { print }
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           git clone https://aur.archlinux.org/telegram-desktop-userfonts.git .
-          sed -e ${SED_PKGBUILD} -i PKGBUILD
+          echo "${AWK_PKGBUILD}" | awk -f - PKGBUILD > PKGBUILD.ci
           chown -R nobody .
-          runuser -u nobody -- makepkg --syncdeps --noconfirm --cleanbuild
+          runuser -u nobody -- makepkg --syncdeps --noconfirm --cleanbuild -p PKGBUILD.ci
 
       - name: list built packages
         run: |

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -27,25 +27,12 @@ jobs:
           rm -rf /__t/*
           df -a /
 
-      - name: install sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
-
       - name: build package
         env:
           AWK_PKGBUILD: |
             # turn off too verbose cmake output
             /DCMAKE_VERBOSE_MAKEFILE/ { next }
-            # use sccache in non-unique subdirectory for better hit rate
-            /cmake -B build/ {
-              print "    mv -v tdesktop-*-full tdesktop-full"
-              gsub(/-\$pkgver-/, "-")
-              print
-              print "        -DCMAKE_C_COMPILER_LAUNCHER=sccache \\"
-              print "        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \\"
-              next
-            }
             { print }
-          SCCACHE_GHA_ENABLED: "true"
         run: |
           git clone https://aur.archlinux.org/telegram-desktop-userfonts.git .
           echo "${AWK_PKGBUILD}" | awk -f - PKGBUILD > PKGBUILD.ci

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '[0-9]*'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -3,59 +3,41 @@ on:
   push:
     tags:
       - '[0-9]*'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+      - name: start build container
+        run: podman run -d --name builder -v ${PWD}:/dest docker.io/library/archlinux:base-devel /sbin/init
 
-      - name: prepare build ctnr
+      - name: prepare build environment
         run: |
-          buildah from --name ctnr docker.io/library/archlinux:base-devel
+          podman exec builder bash -ec '
+          pacman-key --init
+          pacman -Sy --noconfirm archlinux-keyring
+          pacman -Su --noconfirm
+          pacman -S --noconfirm sudo git cmake ninja boost qt6-base
+          echo "nobody ALL=(ALL) NOPASSWD: /usr/bin/pacman" | tee -a /etc/sudoers
+          '
 
-          buildah run ctnr pacman-key --init
-          buildah run ctnr pacman --noconfirm -Syu
-          buildah run ctnr pacman --noconfirm -S git
-
-          buildah run ctnr useradd -m dev
-          buildah run ctnr sh -c 'printf "%s\n" "dev ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers.d/dev'
-
-          buildah config -u dev ctnr
-          buildah run ctnr git clone https://aur.archlinux.org/telegram-desktop-userfonts.git /home/dev/telegram-desktop-userfonts
-          buildah config --workingdir /home/dev/telegram-desktop-userfonts ctnr
-
-      - name: build pkg
+      - name: build package
         run: |
-          buildah run ctnr makepkg --noconfirm -s
+          podman exec builder bash -ec '
+          git clone https://aur.archlinux.org/telegram-desktop-userfonts.git /source
+          chown -R nobody /source
+          cd /source
+          runuser -u nobody -- makepkg --syncdeps --noconfirm --cleanbuild
+          '
 
-          buildah run ctnr ls -l
-
-          pkg="$(buildah run ctnr sh -c "printf '%s\n' telegram-desktop-userfonts-*.pkg.*")"
-          buildah run ctnr cat "$pkg" >"$pkg"
-
-          echo "PKG=$pkg" >>$GITHUB_ENV
+      - name: copy built packages
+        run: |
+          podman exec builder bash -ec 'cp -v /source/telegram-desktop-userfonts-*.pkg.* /dest'
+          echo "PKG=$(ls *.pkg.*)" | tee -a $GITHUB_ENV
 
       - name: create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: upload pkg as release asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.PKG }}
-          asset_name: ${{ env.PKG }}
-          asset_content_type: application/zip
+          files: ${{ env.PKG }}

--- a/.github/workflows/buildpkg.yml
+++ b/.github/workflows/buildpkg.yml
@@ -20,8 +20,11 @@ jobs:
           echo "nobody ALL=(ALL) NOPASSWD: /usr/bin/pacman" | tee -a /etc/sudoers
 
       - name: build package
+        env:
+          SED_PKGBUILD: "/CMAKE_VERBOSE_MAKEFILE/d"
         run: |
           git clone https://aur.archlinux.org/telegram-desktop-userfonts.git .
+          sed -e ${SED_PKGBUILD} -i PKGBUILD
           chown -R nobody .
           runuser -u nobody -- makepkg --syncdeps --noconfirm --cleanbuild
 


### PR DESCRIPTION
Also tune PKGBUILD a bit before making a package:
1. Disable verbose cmake output.
2. Disable emitting debuginfo, which makes builds noticeably faster and wastes much less disk space.

Supposedly, this should not affect resulting build artifacts, which are stripped of debug symbols anyway.
